### PR TITLE
Put JWT in header and remove from query

### DIFF
--- a/map-app/src/main/java/net/wasdev/gameon/map/filter/PlayerClient.java
+++ b/map-app/src/main/java/net/wasdev/gameon/map/filter/PlayerClient.java
@@ -195,7 +195,8 @@ public class PlayerClient {
     	}else{
     		client = HttpClientBuilder.create().build();
     	}
-    	HttpGet hg = new HttpGet(playerLocation+"/"+playerId+"?jwt="+jwt);
+    	HttpGet hg = new HttpGet(playerLocation+"/"+playerId);
+    	hg.addHeader("gameon-jwt", jwt);
     	
     	System.out.println("Building web target "+hg.getURI().toString());
      


### PR DESCRIPTION
This PR cannot be done in isolation, it needs the corresponding requests in map, player and webapp which are for the move_jwt_to_headers branch.

Moves any use of the jwt query param to a gameon-jwt HTTP header.