### PR TITLE
fix broken query by name

### DIFF
--- a/map-app/src/main/java/org/gameontext/map/db/SiteDocuments.java
+++ b/map-app/src/main/java/org/gameontext/map/db/SiteDocuments.java
@@ -130,7 +130,7 @@ public class SiteDocuments {
 
     private ViewQuery createQueryToNameView(String name) {
         return createQueryWithoutKeys("name")
-                .key(ComplexKey.of(name));
+                .key(name);
     }
 
     private ViewQuery createQueryToOwnerNameView(String owner, String name) {

--- a/map-wlpcfg/servers/gameon-map/server.xml
+++ b/map-wlpcfg/servers/gameon-map/server.xml
@@ -47,7 +47,7 @@
     <config updateTrigger="mbean" />
     <applicationMonitor dropinsEnabled="false" updateTrigger="mbean"/>
 
-    <logging traceSpecification="*=info:org.gameontext.*=all"/>
+    <logging traceSpecification="*=info:org.gameontext.*=all:org.gameontext.signed.*=warning"/>
 
     <!-- This is required to prevent the web apps from being lazily loaded -->
     <webContainer deferServletLoad="false"/>


### PR DESCRIPTION
Cloudant is no longer accepting key=["value"] (URL encoded punctuation) anymore. For single values, must be key="value".

TBH, this falls in the "we're not sure how this ever worked" category.

Signed-off-by: Erin Schnabel <schnabel@us.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gameontext/gameon-map/102)
<!-- Reviewable:end -->
